### PR TITLE
return 0 should be added, because of set -e 

### DIFF
--- a/ch11/cgroups/cgroupsv2_explore
+++ b/ch11/cgroups/cgroupsv2_explore
@@ -199,6 +199,7 @@ cpu_ctrl_show()
   [[ ! -z "${cpu_max}" ]] &&         printf "      %-41s   : %s\n" "cpu.max" "${cpu_max}"
   [[ ! -z "${cpu_pressure}" ]] &&    printf "      %-39s   : %s\n" "cpu.pressure" "${cpu_pressure}"
  fi
+ return 0
 }
 
 # Params:

--- a/ch5/core_lkm/Makefile
+++ b/ch5/core_lkm/Makefile
@@ -1,0 +1,266 @@
+# ch5/lkm_template/Makefile
+# ***************************************************************
+# This program is part of the source code released for the book
+#  "Linux Kernel Programming" 2E
+#  (c) Author: Kaiwan N Billimoria
+#  Publisher:  Packt
+#  GitHub repository:
+#  https://github.com/PacktPublishing/Linux-Kernel-Programming_2E
+#
+# From: Ch 5 : Writing Your First Kernel Module LKMs, Part 2
+# ***************************************************************
+# Brief Description:
+# A 'better' Makefile template for Linux LKMs (Loadable Kernel Modules); besides
+# the 'usual' targets (the build, install and clean), we incorporate targets to
+# do useful (and indeed required) stuff like:
+#  - adhering to kernel coding style (indent+checkpatch)
+#  - several static analysis targets (via sparse, gcc, flawfinder, cppcheck)
+#  - two _dummy_ dynamic analysis targets (KASAN, LOCKDEP); just to remind you!
+#  - a packaging (.tar.xz) target and
+#  - a help target.
+#
+# To get started, just type:
+#  make help
+#
+# For details, please refer the book, Ch 5, section
+# 'A "better" Makefile template for your kernel modules'.
+
+#--- To support cross-compiling for kernel modules
+# For architecture (cpu) 'arch', invoke make as:
+#  make ARCH=<arch> CROSS_COMPILE=<cross-compiler-prefix>
+# F.e. to cross-compile for the AArch64:
+#  make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
+#
+# Alternately:
+#  export ARCH=<arch>
+#  export CROSS_COMPILE=<cross-compiler-prefix>
+#  make
+#
+# The KDIR var is set to a sample path below; you're expected to update it on
+# your box to the appropriate path to the kernel source tree for that arch.
+ifeq ($(ARCH),arm)
+  # *UPDATE* 'KDIR' below to point to the ARM Linux kernel source tree on your box
+  KDIR ?= ~/arm_prj/kernel/linux
+else ifeq ($(ARCH),arm64)
+  # *UPDATE* 'KDIR' below to point to the ARM64 (Aarch64) Linux kernel source
+  # tree on your box
+  KDIR ?= ~/arm64_prj/kernel/linux-5.10.60
+else ifeq ($(ARCH),powerpc)
+  # *UPDATE* 'KDIR' below to point to the PPC64 Linux kernel source tree on your box
+  KDIR ?= ~/ppc_prj/kernel/linux-5.4
+else
+  # 'KDIR' is the Linux 'kernel headers' package on your host system; this is
+  # usually an x86_64, but could be anything, really (f.e. building directly
+  # on a Raspberry Pi implies that it's the host)
+  KDIR ?= /lib/modules/$(shell uname -r)/build
+endif
+#---
+
+# Compiler
+CC     := $(CROSS_COMPILE)gcc
+#CC    := clang
+STRIP := ${CROSS_COMPILE}strip
+
+PWD            := $(shell pwd)
+obj-m          := core_lkm.o
+
+# Set the MYDEBUG variable accordingly to y/n resp. We keep it off (n) by default.
+# (Actually, debug info is always going to be generated when you build the
+# module on a debug kernel, where CONFIG_DEBUG_INFO is defined, making this
+# setting of the ccflags-y (or the older EXTRA_CFLAGS) variable mostly redundant
+# (besides the still useful -DDEBUG).
+# This simply helps us influence the build on a production kernel, forcing
+# generation of debug symbols, if so required. Also, realize that the DEBUG
+# macro is turned on by many CONFIG_*DEBUG* options; hence, we use a different
+# macro var name, MYDEBUG).
+MYDEBUG := y
+ifeq (${MYDEBUG}, y)
+# https://www.kernel.org/doc/html/latest/kbuild/makefiles.html#compilation-flags
+# EXTRA_CFLAGS deprecated; use ccflags-y
+  ccflags-y   += -DDEBUG -g -ggdb -gdwarf-4 -Wall -fno-omit-frame-pointer -fvar-tracking-assignments
+else
+  INSTALL_MOD_STRIP := 1
+  ccflags-y   += -UDEBUG
+endif
+# We always keep the dynamic debug facility enabled; this allows us to turn
+# dynamically turn on/off debug printk's later... To disable it simply comment
+# out the following line
+ccflags-y   += -DDYNAMIC_DEBUG_MODULE
+
+KMODDIR ?= /lib/modules/$(shell uname -r)
+
+all:
+	@echo
+	@echo '--- Building : KDIR=${KDIR} ARCH=${ARCH} CROSS_COMPILE=${CROSS_COMPILE} ccflags-y="${ccflags-y}" MYDEBUG=${MYDEBUG} ---'
+	@${CC} --version|head -n1
+	@echo
+	make -C $(KDIR) M=$(PWD) modules
+#	Strip: only strip debug symbols else it won't load correctly
+	if [ "${MYDEBUG}" != "y" ]; then \
+	   ${STRIP} --strip-debug core_lkm.ko ; \
+	fi
+install:
+	@echo
+	@echo "--- installing ---"
+	@echo " [First, invoking the 'make' ]"
+	make
+	@echo
+	@echo " [Now for the 'sudo make install' ]"
+	sudo make -C $(KDIR) M=$(PWD) modules_install
+	sudo depmod
+#	Strip: only strip debug symbols else it won't load correctly
+	@echo " [If !debug, stripping debug info from ${KMODDIR}/extra/ core_lkm and user_lkm .ko's]"
+	if [ "${MYDEBUG}" != "y" ]; then \
+	   sudo ${STRIP} --strip-debug ${KMODDIR}/extra/core_lkm.ko ; \
+	   sudo ${STRIP} --strip-debug ${KMODDIR}/extra/user_lkm.ko ; \
+	fi
+nsdeps:
+	@echo "--- nsdeps (namespace dependencies resolution; for possibly importing ns's) ---"
+	make -C $(KDIR) M=$(PWD) nsdeps
+clean:
+	@echo
+	@echo "--- cleaning ---"
+	@echo
+	make -C $(KDIR) M=$(PWD) clean
+# from 'indent'; comment out if you want the backup kept
+	rm -f *~
+
+# Any usermode programs to build? Insert the build target(s) below
+
+
+#--------------- More (useful) targets! -------------------------------
+INDENT := indent
+
+# code-style : "wrapper" target over the following kernel code style targets
+code-style:
+	make indent
+	make checkpatch
+
+# indent- "beautifies" C code - to conform to the the Linux kernel
+# coding style guidelines.
+# Note! original source file(s) is overwritten, so we back it up.
+indent:
+ifeq (,$(shell which indent))
+	$(error ERROR: install indent first)
+endif
+	@echo
+	@echo "--- applying kernel code style indentation with indent ---"
+	@echo
+	mkdir bkp 2> /dev/null; cp -f *.[chsS] bkp/
+	${INDENT} -linux --line-length95 *.[chsS]
+	  # add source files as required
+
+# Detailed check on the source code styling / etc
+checkpatch:
+	make clean
+	@echo
+	@echo "--- kernel code style check with checkpatch.pl ---"
+	@echo
+	$(KDIR)/scripts/checkpatch.pl --no-tree -f --max-line-length=95 *.[ch]
+	  # add source files as required
+
+#--- Static Analysis
+# sa : "wrapper" target over the following kernel static analyzer targets
+sa:
+	make sa_sparse
+	make sa_gcc
+	make sa_flawfinder
+	make sa_cppcheck
+
+# static analysis with sparse
+sa_sparse:
+ifeq (,$(shell which sparse))
+	$(error ERROR: install sparse first)
+endif
+
+	make clean
+	@echo
+	@echo "--- static analysis with sparse ---"
+	@echo
+# if you feel it's too much, use C=1 instead
+# NOTE: deliberately IGNORING warnings from kernel headers!
+	make -Wsparse-all C=2 CHECK="/usr/bin/sparse --os=linux --arch=$(ARCH)" -C $(KDIR) M=$(PWD) modules 2>&1 |egrep -v "^\./include/.*\.h|^\./arch/.*\.h"
+
+# static analysis with gcc
+sa_gcc:
+	make clean
+	@echo
+	@echo "--- static analysis with gcc ---"
+	@echo
+	make W=1 -C $(KDIR) M=$(PWD) modules
+
+# static analysis with flawfinder
+sa_flawfinder:
+ifeq (,$(shell which flawfinder))
+	$(error ERROR: install flawfinder first)
+endif
+	make clean
+	@echo
+	@echo "--- static analysis with flawfinder ---"
+	@echo
+	flawfinder *.[ch]
+
+# static analysis with cppcheck
+sa_cppcheck:
+ifeq (,$(shell which cppcheck))
+	$(error ERROR: install cppcheck first)
+endif
+	make clean
+	@echo
+	@echo "--- static analysis with cppcheck ---"
+	@echo
+	cppcheck -v --force --enable=all -i .tmp_versions/ -i *.mod.c -i bkp/ --suppress=missingIncludeSystem .
+
+# Packaging; just tar.xz as of now
+PKG_NAME := ch5_modstacking
+tarxz-pkg:
+	rm -f ../${PKG_NAME}.tar.xz 2>/dev/null
+	make clean
+	@echo
+	@echo "--- packaging ---"
+	@echo
+	tar caf ../${PKG_NAME}.tar.xz *
+	ls -l ../${PKG_NAME}.tar.xz
+	@echo '=== package created: ../$(PKG_NAME).tar.xz ==='
+	@echo '        TIP: When extracting, to extract into a directory with the same name as the tar file, do this:'
+	@echo '              tar -xvf ${PKG_NAME}.tar.xz --one-top-level'
+
+help:
+	@echo '=== Makefile Help : additional targets available ==='
+	@echo
+	@echo 'TIP: Type make <tab><tab> to show all valid targets'
+	@echo
+
+	@echo '--- 'usual' kernel LKM targets ---'
+	@echo 'typing "make" or "all" target : builds the kernel module object (the .ko)'
+	@echo 'install     : installs the kernel module(s) to INSTALL_MOD_PATH (default here: /lib/modules/$(shell uname -r)/)'
+	@echo 'nsdeps      : namespace dependencies resolution; for possibly importing namespaces'
+	@echo 'clean       : cleanup - remove all kernel objects, temp files/dirs, etc'
+
+	@echo
+	@echo '--- kernel code style targets ---'
+	@echo 'code-style : "wrapper" target over the following kernel code style targets'
+	@echo ' indent     : run the $(INDENT) utility on source file(s) to indent them as per the kernel code style'
+	@echo ' checkpatch : run the kernel code style checker tool on source file(s)'
+
+	@echo
+	@echo '--- kernel static analyzer targets ---'
+	@echo 'sa         : "wrapper" target over the following kernel static analyzer targets'
+	@echo ' sa_sparse     : run the static analysis sparse tool on the source file(s)'
+	@echo ' sa_gcc        : run gcc with option -W1 ("Generally useful warnings") on the source file(s)'
+	@echo ' sa_flawfinder : run the static analysis flawfinder tool on the source file(s)'
+	@echo ' sa_cppcheck   : run the static analysis cppcheck tool on the source file(s)'
+	@echo 'TIP: use Coccinelle as well: https://www.kernel.org/doc/html/v6.1/dev-tools/coccinelle.html'
+
+	@echo
+	@echo '--- kernel dynamic analysis targets ---'
+	@echo 'da_kasan   : DUMMY target: this is to remind you to run your code with the dynamic analysis KASAN tool enabled; requires configuring the kernel with CONFIG_KASAN On, rebuild and boot it'
+	@echo 'da_lockdep : DUMMY target: this is to remind you to run your code with the dynamic analysis LOCKDEP tool (for deep locking issues analysis) enabled; requires configuring the kernel with CONFIG_PROVE_LOCKING On, rebuild and boot it'
+	@echo 'TIP: Best to build a debug kernel with several kernel debug config options turned On, boot via it and run all your test cases'
+
+	@echo
+	@echo '--- misc targets ---'
+	@echo 'tarxz-pkg  : tar and compress the LKM source files as a tar.xz into the dir above; allows one to transfer and build the module on another system'
+	@echo '        TIP: When extracting, to extract into a directory with the same name as the tar file, do this:'
+	@echo '              tar -xvf ${PKG_NAME}.tar.xz --one-top-level'
+	@echo 'help       : this help target'

--- a/ch5/core_lkm/core_lkm.c
+++ b/ch5/core_lkm/core_lkm.c
@@ -1,0 +1,127 @@
+/*
+ * ch5/modstacking/core_lkm.c
+ ***************************************************************
+ * This program is part of the source code released for the book
+ *  "Linux Kernel Programming" 2E
+ *  (c) Author: Kaiwan N Billimoria
+ *  Publisher:  Packt
+ *  GitHub repository:
+ *  https://github.com/PacktPublishing/Linux-Kernel-Programming_2E
+ *
+ * From: Ch 5: Writing your First Kernel Module- LKMs Part 2
+ ****************************************************************
+ * Brief Description:
+ * This kernel module - core_lkm - is part of the 'modstacking' POC project:
+ *    user_lkm
+ *        |
+ *    core_lkm           [<--- this code]
+ * The user_lkm kernel module calls an (exported) function that resides
+ * in the core_lkm kernel module.
+ *
+ * For details, please refer the book, Ch 5.
+ */
+#define pr_fmt(fmt) "%s:%s(): " fmt, KBUILD_MODNAME, __func__
+
+#include <linux/init.h>
+#include <linux/module.h>
+#include "../../convenient.h"
+
+#define THE_ONE   0xfedface
+MODULE_LICENSE("Dual MIT/GPL");
+
+int exp_int = 200;
+EXPORT_SYMBOL_GPL(exp_int);
+
+/* Functions to be called from other LKMs */
+
+/* llkd_sysinfo2:
+ * A more security-aware version of the earlier llkd_sysinfo() routine. We use
+ * David Wheeler's flawfinder(1) tool to detect possible vulnerabilities;
+ * Based on it's report, we change the strlen, and replace the strncat with
+ * strlcat.
+ */
+void llkd_sysinfo2(void)
+{
+#define MSGLEN   128
+	char msg[MSGLEN];
+
+	memset(msg, 0, MSGLEN);
+	/* We don't use our snprintf_lkp() wrapper here as that will require
+	 * linking into the klib.c file... here, we're demo-ing the module
+	 * stacking approach, as opposed to the 'library' link approach, so
+	 * we pedantically avoid it. Don't have any such qualms in production;
+	 * simply use it and link appropriately.
+	 */
+	snprintf(msg, 48, "%s(): minimal Platform Info:\nCPU: ", __func__);
+	//snprintf_lkp(msg, 48, "%s(): minimal Platform Info:\nCPU: ", __func__);
+
+	/* Strictly speaking, all this #if... is considered ugly and should be
+	 * isolated as far as is possible
+	 */
+#ifdef CONFIG_X86
+#if (BITS_PER_LONG == 32)
+	strlcat(msg, "x86_32, ", MSGLEN);
+#else
+	strlcat(msg, "x86_64, ", MSGLEN);
+#endif
+#endif
+#ifdef CONFIG_ARM
+	strlcat(msg, "ARM-32, ", MSGLEN);
+#endif
+#ifdef CONFIG_ARM64
+	strlcat(msg, "Aarch64, ", MSGLEN);
+#endif
+#ifdef CONFIG_MIPS
+	strlcat(msg, "MIPS, ", MSGLEN);
+#endif
+#ifdef CONFIG_PPC
+	strlcat(msg, "PowerPC, ", MSGLEN);
+#endif
+#ifdef CONFIG_S390
+	strlcat(msg, "IBM S390, ", MSGLEN);
+#endif
+
+#ifdef __BIG_ENDIAN
+	strlcat(msg, "big-endian; ", MSGLEN);
+#else
+	strlcat(msg, "little-endian; ", MSGLEN);
+#endif
+
+#if (BITS_PER_LONG == 32)
+	strlcat(msg, "32-bit OS.\n", MSGLEN);
+#elif(BITS_PER_LONG == 64)
+	strlcat(msg, "64-bit OS.\n", MSGLEN);
+#endif
+	pr_info("%s", msg);
+}
+EXPORT_SYMBOL(llkd_sysinfo2);
+
+#if (BITS_PER_LONG == 32)
+u32 get_skey(int p)
+#else				// 64-bit
+u64 get_skey(int p)
+#endif
+{
+#if (BITS_PER_LONG == 32)
+	u32 secret = 0x567def;
+#else				// 64-bit
+	u64 secret = 0x123abc567def;
+#endif
+	pr_info("%s:%d: I've been called\n", __FILE__, __LINE__);
+	if (p == THE_ONE)
+		return secret;
+	return 0;
+}
+EXPORT_SYMBOL(get_skey);
+
+static int __init core_lkm_init(void)
+{
+	pr_info("inserted\nExported: get_skey(), llkd_sysinfo2() and exp_int\n");
+	return 0;	/* success */
+}
+static void __exit core_lkm_exit(void)
+{
+	pr_info("bids you adieu\n");
+}
+module_init(core_lkm_init);
+module_exit(core_lkm_exit);

--- a/ch5/user_lkm/Makefile
+++ b/ch5/user_lkm/Makefile
@@ -1,0 +1,267 @@
+# ch5/lkm_template/Makefile
+# ***************************************************************
+# This program is part of the source code released for the book
+#  "Linux Kernel Programming" 2E
+#  (c) Author: Kaiwan N Billimoria
+#  Publisher:  Packt
+#  GitHub repository:
+#  https://github.com/PacktPublishing/Linux-Kernel-Programming_2E
+#
+# From: Ch 5 : Writing Your First Kernel Module LKMs, Part 2
+# ***************************************************************
+# Brief Description:
+# A 'better' Makefile template for Linux LKMs (Loadable Kernel Modules); besides
+# the 'usual' targets (the build, install and clean), we incorporate targets to
+# do useful (and indeed required) stuff like:
+#  - adhering to kernel coding style (indent+checkpatch)
+#  - several static analysis targets (via sparse, gcc, flawfinder, cppcheck)
+#  - two _dummy_ dynamic analysis targets (KASAN, LOCKDEP); just to remind you!
+#  - a packaging (.tar.xz) target and
+#  - a help target.
+#
+# To get started, just type:
+#  make help
+#
+# For details, please refer the book, Ch 5, section
+# 'A "better" Makefile template for your kernel modules'.
+
+#--- To support cross-compiling for kernel modules
+# For architecture (cpu) 'arch', invoke make as:
+#  make ARCH=<arch> CROSS_COMPILE=<cross-compiler-prefix>
+# F.e. to cross-compile for the AArch64:
+#  make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
+#
+# Alternately:
+#  export ARCH=<arch>
+#  export CROSS_COMPILE=<cross-compiler-prefix>
+#  make
+#
+# The KDIR var is set to a sample path below; you're expected to update it on
+# your box to the appropriate path to the kernel source tree for that arch.
+ifeq ($(ARCH),arm)
+  # *UPDATE* 'KDIR' below to point to the ARM Linux kernel source tree on your box
+  KDIR ?= ~/arm_prj/kernel/linux
+else ifeq ($(ARCH),arm64)
+  # *UPDATE* 'KDIR' below to point to the ARM64 (Aarch64) Linux kernel source
+  # tree on your box
+  KDIR ?= ~/arm64_prj/kernel/linux-5.10.60
+else ifeq ($(ARCH),powerpc)
+  # *UPDATE* 'KDIR' below to point to the PPC64 Linux kernel source tree on your box
+  KDIR ?= ~/ppc_prj/kernel/linux-5.4
+else
+  # 'KDIR' is the Linux 'kernel headers' package on your host system; this is
+  # usually an x86_64, but could be anything, really (f.e. building directly
+  # on a Raspberry Pi implies that it's the host)
+  KDIR ?= /lib/modules/$(shell uname -r)/build
+endif
+#---
+
+# Compiler
+CC     := $(CROSS_COMPILE)gcc
+#CC    := clang
+STRIP := ${CROSS_COMPILE}strip
+
+PWD            := $(shell pwd)
+obj-m          := user_lkm.o 
+
+#--- Debug or production mode?
+# Set the MYDEBUG variable accordingly to y/n resp. We keep it off (n) by default.
+# (Actually, debug info is always going to be generated when you build the
+# module on a debug kernel, where CONFIG_DEBUG_INFO is defined, making this
+# setting of the ccflags-y (or the older EXTRA_CFLAGS) variable mostly redundant
+# (besides the still useful -DDEBUG).
+# This simply helps us influence the build on a production kernel, forcing
+# generation of debug symbols, if so required. Also, realize that the DEBUG
+# macro is turned on by many CONFIG_*DEBUG* options; hence, we use a different
+# macro var name, MYDEBUG).
+MYDEBUG := y
+ifeq (${MYDEBUG}, y)
+# https://www.kernel.org/doc/html/latest/kbuild/makefiles.html#compilation-flags
+# EXTRA_CFLAGS deprecated; use ccflags-y
+  ccflags-y   += -DDEBUG -g -ggdb -gdwarf-4 -Wall -fno-omit-frame-pointer -fvar-tracking-assignments
+else
+  INSTALL_MOD_STRIP := 1
+  ccflags-y   += -UDEBUG
+endif
+# We always keep the dynamic debug facility enabled; this allows us to turn
+# dynamically turn on/off debug printk's later... To disable it simply comment
+# out the following line
+ccflags-y   += -DDYNAMIC_DEBUG_MODULE
+
+KMODDIR ?= /lib/modules/$(shell uname -r)
+
+all:
+	@echo
+	@echo '--- Building : KDIR=${KDIR} ARCH=${ARCH} CROSS_COMPILE=${CROSS_COMPILE} ccflags-y="${ccflags-y}" MYDEBUG=${MYDEBUG} ---'
+	@${CC} --version|head -n1
+	@echo
+	make -C $(KDIR) M=$(PWD) KBUILD_EXTRA_SYMBOLS=$(PWD)/../core_lkm/Module.symvers modules
+#	Strip: only strip debug symbols else it won't load correctly
+	if [ "${MYDEBUG}" != "y" ]; then \
+	   ${STRIP} --strip-debug user_lkm.ko ; \
+	fi
+install:
+	@echo
+	@echo "--- installing ---"
+	@echo " [First, invoking the 'make' ]"
+	make
+	@echo
+	@echo " [Now for the 'sudo make install' ]"
+	sudo make -C $(KDIR) M=$(PWD) modules_install
+	sudo depmod
+#	Strip: only strip debug symbols else it won't load correctly
+	@echo " [If !debug, stripping debug info from ${KMODDIR}/extra/ core_lkm and user_lkm .ko's]"
+	if [ "${MYDEBUG}" != "y" ]; then \
+	   sudo ${STRIP} --strip-debug ${KMODDIR}/extra/core_lkm.ko ; \
+	   sudo ${STRIP} --strip-debug ${KMODDIR}/extra/user_lkm.ko ; \
+	fi
+nsdeps:
+	@echo "--- nsdeps (namespace dependencies resolution; for possibly importing ns's) ---"
+	make -C $(KDIR) M=$(PWD) nsdeps
+clean:
+	@echo
+	@echo "--- cleaning ---"
+	@echo
+	make -C $(KDIR) M=$(PWD) clean
+# from 'indent'; comment out if you want the backup kept
+	rm -f *~
+
+# Any usermode programs to build? Insert the build target(s) below
+
+
+#--------------- More (useful) targets! -------------------------------
+INDENT := indent
+
+# code-style : "wrapper" target over the following kernel code style targets
+code-style:
+	make indent
+	make checkpatch
+
+# indent- "beautifies" C code - to conform to the the Linux kernel
+# coding style guidelines.
+# Note! original source file(s) is overwritten, so we back it up.
+indent:
+ifeq (,$(shell which indent))
+	$(error ERROR: install indent first)
+endif
+	@echo
+	@echo "--- applying kernel code style indentation with indent ---"
+	@echo
+	mkdir bkp 2> /dev/null; cp -f *.[chsS] bkp/
+	${INDENT} -linux --line-length95 *.[chsS]
+	  # add source files as required
+
+# Detailed check on the source code styling / etc
+checkpatch:
+	make clean
+	@echo
+	@echo "--- kernel code style check with checkpatch.pl ---"
+	@echo
+	$(KDIR)/scripts/checkpatch.pl --no-tree -f --max-line-length=95 *.[ch]
+	  # add source files as required
+
+#--- Static Analysis
+# sa : "wrapper" target over the following kernel static analyzer targets
+sa:
+	make sa_sparse
+	make sa_gcc
+	make sa_flawfinder
+	make sa_cppcheck
+
+# static analysis with sparse
+sa_sparse:
+ifeq (,$(shell which sparse))
+	$(error ERROR: install sparse first)
+endif
+
+	make clean
+	@echo
+	@echo "--- static analysis with sparse ---"
+	@echo
+# if you feel it's too much, use C=1 instead
+# NOTE: deliberately IGNORING warnings from kernel headers!
+	make -Wsparse-all C=2 CHECK="/usr/bin/sparse --os=linux --arch=$(ARCH)" -C $(KDIR) M=$(PWD) modules 2>&1 |egrep -v "^\./include/.*\.h|^\./arch/.*\.h"
+
+# static analysis with gcc
+sa_gcc:
+	make clean
+	@echo
+	@echo "--- static analysis with gcc ---"
+	@echo
+	make W=1 -C $(KDIR) M=$(PWD) modules
+
+# static analysis with flawfinder
+sa_flawfinder:
+ifeq (,$(shell which flawfinder))
+	$(error ERROR: install flawfinder first)
+endif
+	make clean
+	@echo
+	@echo "--- static analysis with flawfinder ---"
+	@echo
+	flawfinder *.[ch]
+
+# static analysis with cppcheck
+sa_cppcheck:
+ifeq (,$(shell which cppcheck))
+	$(error ERROR: install cppcheck first)
+endif
+	make clean
+	@echo
+	@echo "--- static analysis with cppcheck ---"
+	@echo
+	cppcheck -v --force --enable=all -i .tmp_versions/ -i *.mod.c -i bkp/ --suppress=missingIncludeSystem .
+
+# Packaging; just tar.xz as of now
+PKG_NAME := ch5_modstacking
+tarxz-pkg:
+	rm -f ../${PKG_NAME}.tar.xz 2>/dev/null
+	make clean
+	@echo
+	@echo "--- packaging ---"
+	@echo
+	tar caf ../${PKG_NAME}.tar.xz *
+	ls -l ../${PKG_NAME}.tar.xz
+	@echo '=== package created: ../$(PKG_NAME).tar.xz ==='
+	@echo '        TIP: When extracting, to extract into a directory with the same name as the tar file, do this:'
+	@echo '              tar -xvf ${PKG_NAME}.tar.xz --one-top-level'
+
+help:
+	@echo '=== Makefile Help : additional targets available ==='
+	@echo
+	@echo 'TIP: Type make <tab><tab> to show all valid targets'
+	@echo
+
+	@echo '--- 'usual' kernel LKM targets ---'
+	@echo 'typing "make" or "all" target : builds the kernel module object (the .ko)'
+	@echo 'install     : installs the kernel module(s) to INSTALL_MOD_PATH (default here: /lib/modules/$(shell uname -r)/)'
+	@echo 'nsdeps      : namespace dependencies resolution; for possibly importing namespaces'
+	@echo 'clean       : cleanup - remove all kernel objects, temp files/dirs, etc'
+
+	@echo
+	@echo '--- kernel code style targets ---'
+	@echo 'code-style : "wrapper" target over the following kernel code style targets'
+	@echo ' indent     : run the $(INDENT) utility on source file(s) to indent them as per the kernel code style'
+	@echo ' checkpatch : run the kernel code style checker tool on source file(s)'
+
+	@echo
+	@echo '--- kernel static analyzer targets ---'
+	@echo 'sa         : "wrapper" target over the following kernel static analyzer targets'
+	@echo ' sa_sparse     : run the static analysis sparse tool on the source file(s)'
+	@echo ' sa_gcc        : run gcc with option -W1 ("Generally useful warnings") on the source file(s)'
+	@echo ' sa_flawfinder : run the static analysis flawfinder tool on the source file(s)'
+	@echo ' sa_cppcheck   : run the static analysis cppcheck tool on the source file(s)'
+	@echo 'TIP: use Coccinelle as well: https://www.kernel.org/doc/html/v6.1/dev-tools/coccinelle.html'
+
+	@echo
+	@echo '--- kernel dynamic analysis targets ---'
+	@echo 'da_kasan   : DUMMY target: this is to remind you to run your code with the dynamic analysis KASAN tool enabled; requires configuring the kernel with CONFIG_KASAN On, rebuild and boot it'
+	@echo 'da_lockdep : DUMMY target: this is to remind you to run your code with the dynamic analysis LOCKDEP tool (for deep locking issues analysis) enabled; requires configuring the kernel with CONFIG_PROVE_LOCKING On, rebuild and boot it'
+	@echo 'TIP: Best to build a debug kernel with several kernel debug config options turned On, boot via it and run all your test cases'
+
+	@echo
+	@echo '--- misc targets ---'
+	@echo 'tarxz-pkg  : tar and compress the LKM source files as a tar.xz into the dir above; allows one to transfer and build the module on another system'
+	@echo '        TIP: When extracting, to extract into a directory with the same name as the tar file, do this:'
+	@echo '              tar -xvf ${PKG_NAME}.tar.xz --one-top-level'
+	@echo 'help       : this help target'

--- a/ch5/user_lkm/user_lkm.c
+++ b/ch5/user_lkm/user_lkm.c
@@ -1,0 +1,60 @@
+/*
+ * ch5/modstacking/user_lkm.c
+ ***************************************************************
+ * This program is part of the source code released for the book
+ *  "Linux Kernel Programming" 2E
+ *  (c) Author: Kaiwan N Billimoria
+ *  Publisher:  Packt
+ *  GitHub repository:
+ *  https://github.com/PacktPublishing/Linux-Kernel-Programming_2E
+ *
+ * From: Ch 5: Writing your First Kernel Module- LKMs Part 2
+ ****************************************************************
+ * Brief Description:
+ * This kernel module - user_lkm - is part of the 'modstacking' POC project:
+ *    user_lkm           [<--- this code]
+ *        |
+ *    core_lkm
+ * The user_lkm kernel module calls an (exported) function that resides
+ * in the core_lkm kernel module.
+ *
+ * For details, please refer the book, Ch 5.
+ */
+#define pr_fmt(fmt) "%s:%s(): " fmt, KBUILD_MODNAME, __func__
+
+#include <linux/init.h>
+#include <linux/module.h>
+
+#if 1
+MODULE_LICENSE("Dual MIT/GPL");
+#else
+MODULE_LICENSE("MIT");
+#endif
+
+extern void llkd_sysinfo2(void);
+extern long get_skey(int);
+extern int exp_int;
+
+/* Call some functions within the 'core' module */
+static int __init user_lkm_init(void)
+{
+	u64 sk;
+
+#define THE_ONE   0xfedface
+	pr_info("inserted\n");
+	sk = get_skey(THE_ONE);
+
+	pr_debug("Called get_skey(), ret = 0x%llx = %llu\n", sk, sk);
+	pr_debug("exp_int = %d\n", exp_int);
+	llkd_sysinfo2();
+
+	return 0;
+}
+
+static void __exit user_lkm_exit(void)
+{
+	pr_info("bids you adieu\n");
+}
+
+module_init(user_lkm_init);
+module_exit(user_lkm_exit);


### PR DESCRIPTION
Running ch11/cgroups/cgroupsv2_explore doesn't show memory information and footnote,
When CPU controller is disabled && memory controller is enabled.

