### PR TITLE
Fix incorrect CPU core count when displaying affinity mask

### DIFF
--- a/ch11/cpu_affinity/userspc_cpuaffinity.c
+++ b/ch11/cpu_affinity/userspc_cpuaffinity.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/sysinfo.h>
 #include <sched.h>
 #include "../../convenient.h"
 
@@ -122,8 +123,6 @@ static int set_cpu_affinity(pid_t pid, unsigned long bitmask)
 
 int main (int argc, char **argv)
 {
-	FILE *fp;
-	char s[9];
 	pid_t pid = getpid();
 	unsigned long new_cpumask = 0x0;
 
@@ -136,18 +135,7 @@ int main (int argc, char **argv)
 		exit(EXIT_SUCCESS);
 	}
 
-	fp = popen("nproc", "r");
-	if (!fp) {
-		fprintf(stderr, "%s: popen failed; can't detect number of cores, aborting...\n", argv[0]);
-		exit(EXIT_FAILURE);
-	}
-	if (!fgets(s, sizeof(s), fp)) {
-		fprintf(stderr, "%s: fgets failed to read data; can't detect number of cores, aborting...\n", argv[0]);
-		pclose(fp);
-		exit(EXIT_FAILURE);
-	}
-	pclose(fp);
-	numcores = atoi(s);
+	numcores = get_nprocs();
 	printf("Detected %d CPU cores [for this process %s:%d]\n", numcores, argv[0], getpid());
 	/* we say 'for this process ...' as the number of cores available to processes can
 	 * change within a container


### PR DESCRIPTION
The current implementation uses `nproc` to query the number of available CPUs. However, when restricting the cores that `userspc_cpuaffinity` can run on (e.g., via `taskset -c`), the affinity mask table is incorrectly displayed.

For example, continuing the procedure mentioned in the book at _Figure 11.2_, after changing the affinity of the current bash process, we run the `userspc_cpuaffinity` one more time:

```bash
$ nproc 
8

$ ps
    PID TTY          TIME CMD
  19217 pts/0    00:00:00 bash
  19781 pts/0    00:00:00 ps

$ sudo ./userspc_cpuaffinity 19217 0x0f
Detected 8 CPU cores [for this process ./userspc_cpuaffinity:19870]
CPU affinity mask for PID 19217:
  19217 pts/0    00:00:00 bash
       +---+---+---+---+---+---+---+---+
core#  |  7|  6|  5|  4|  3|  2|  1|  0|
       +---+---+---+---+---+---+---+---+
cpumask|  1|  1|  1|  1|  1|  1|  1|  1|
       +---+---+---+---+---+---+---+---+

Setting CPU affinity mask for PID 19217 now...
CPU affinity mask for PID 19217:
  19217 pts/0    00:00:00 bash
       +---+---+---+---+---+---+---+---+
core#  |  7|  6|  5|  4|  3|  2|  1|  0|
       +---+---+---+---+---+---+---+---+
cpumask|  0|  0|  0|  0|  1|  1|  1|  1|
       +---+---+---+---+---+---+---+---+

$ nproc 
4

$ ./userspc_cpuaffinity
Detected 4 CPU cores [for this process ./userspc_cpuaffinity:19956]
CPU affinity mask for PID 19956:
  19956 pts/0    00:00:00 userspc_cpuaffi
       +---+---+---+---+
core#  |  3|  2|  1|  0|
       +---+---+---+---+
cpumask|  1|  1|  1|  1|
       +---+---+---+---+
```

Or just running the `userspc_cpuaffinity` in a new terminal with `taskset`:

```bash
$ taskset -c 3 ./userspc_cpuaffinity
Detected 1 CPU cores [for this process ./userspc_cpuaffinity:20452]
CPU affinity mask for PID 20452:
  20452 pts/1    00:00:00 userspc_cpuaffi
       +---+
core#  |  0|
       +---+
cpumask|  0|
       +---+
```

This commit resolves the issue by replacing `nproc` with `get_nprocs()` from `sys/sysinfo.h`, which provides the correct number of processors after core restrictions are applied. The examples now run correctly after the change:

```bash
$ nproc 
8

$ ps
    PID TTY          TIME CMD
  20510 pts/2    00:00:00 bash
  28515 pts/2    00:00:00 ps

$ sudo ./userspc_cpuaffinity 20510 0x0f
Detected 8 CPU cores [for this process ./userspc_cpuaffinity:28631]
CPU affinity mask for PID 20510:
  20510 pts/2    00:00:00 bash
       +---+---+---+---+---+---+---+---+
core#  |  7|  6|  5|  4|  3|  2|  1|  0|
       +---+---+---+---+---+---+---+---+
cpumask|  1|  1|  1|  1|  1|  1|  1|  1|
       +---+---+---+---+---+---+---+---+

Setting CPU affinity mask for PID 20510 now...
CPU affinity mask for PID 20510:
  20510 pts/2    00:00:00 bash
       +---+---+---+---+---+---+---+---+
core#  |  7|  6|  5|  4|  3|  2|  1|  0|
       +---+---+---+---+---+---+---+---+
cpumask|  0|  0|  0|  0|  1|  1|  1|  1|
       +---+---+---+---+---+---+---+---+

$ nproc 
4

$ ./userspc_cpuaffinity
Detected 8 CPU cores [for this process ./userspc_cpuaffinity:28727]
CPU affinity mask for PID 28727:
  28727 pts/2    00:00:00 userspc_cpuaffi
       +---+---+---+---+---+---+---+---+
core#  |  7|  6|  5|  4|  3|  2|  1|  0|
       +---+---+---+---+---+---+---+---+
cpumask|  0|  0|  0|  0|  1|  1|  1|  1|
       +---+---+---+---+---+---+---+---+
```

Or in a new terminal:

```bash
$ taskset -c 3 ./userspc_cpuaffinity
Detected 8 CPU cores [for this process ./userspc_cpuaffinity:28946]
CPU affinity mask for PID 28946:
  28946 pts/2    00:00:00 userspc_cpuaffi
       +---+---+---+---+---+---+---+---+
core#  |  7|  6|  5|  4|  3|  2|  1|  0|
       +---+---+---+---+---+---+---+---+
cpumask|  0|  0|  0|  0|  1|  0|  0|  0|
       +---+---+---+---+---+---+---+---+
```