### PR TITLE
ch10/concurrent_exercise/concurrency: Leave 1 core free to prevent user interaction from hanging on some sy…

### DIFF
--- a/ch10/concurrent_exercise/concurrency
+++ b/ch10/concurrent_exercise/concurrency
@@ -31,7 +31,14 @@ trap 'pkill yes' INT QUIT
 pkill yes
 c=0
 echo "${name}: spawning a 'yes' process on ..."
-while [[ $c -lt $1 ]]
+
+cores2use=$1
+if [[ $1 == $NUMCORES ]]; then
+	echo "Leaving 1 core free for user interaction responsiveness, when $NUMCORES cores are requested"
+	cores2use=$(($1 - 1))
+fi
+
+while [[ $c -lt $cores2use ]]
 do
    echo "... CPU core #$c now ..."
    ${PFX}/exercise_cpu $c &


### PR DESCRIPTION
Running the concurrency program on my VM setup of 4 cores with the command:
```
./concurrency 4 
```
causes 4 yes processes to start on cores 0-3, however trying to kill the processes with 'pkill yes' becomes difficult as the keyboard and terminal responsiveness became too slow. 

Added a change to leave atleast 1 core free, so that responsiveness will always be maintained. 

NOTE: I also tested this on a non-VM system and the user responsiveness was fine even while running 'yes' on all available cores. Therefore, this effect is system dependent. 